### PR TITLE
develop chore: gatsby v4 -> v5 업그레이드

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
 
       # node_modules 캐싱을 이용합니다.
       - name: Cache yarn dependencies
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: node_modules
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -164,4 +164,5 @@ module.exports = {
       },
     },
   ],
+  trailingSlash: 'always',
 };


### PR DESCRIPTION
 - v5 가이드 문서에 표기된 속성값 추가
 - node 18 버전 업그레이드 함에 따라서 git cache action v2 -> v3로 변경