### PR TITLE
fix: 마이그레이션 때 유실된 검색엔진 소유권 확인 메타 태그 복구

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,6 +32,14 @@ export const metadata: Metadata = {
     images: [{ url: ogImagePath[defaultLocale], width: 1200, height: 630 }],
   },
   twitter: { card: 'summary_large_image' },
+  // 루트 레이아웃에 두어 `/`를 포함한 모든 페이지에 실린다.
+  // (서치 콘솔은 속성 루트 URL에서 이 태그를 확인한다)
+  verification: {
+    google: siteConfig.verification.google,
+    other: {
+      'naver-site-verification': siteConfig.verification.naver,
+    },
+  },
 };
 
 export default function RootLayout({

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -14,6 +14,15 @@ export const siteConfig = {
   },
   /** Google Analytics 측정 ID (다음 라운드에서 스크립트 연결) */
   gaIds: ['G-TYGQRJE1B8', 'G-G8Z1HZWWYL'],
+  /**
+   * 검색 콘솔 소유권 확인 토큰.
+   * Gatsby 시절 `<meta>`로 심어 두었던 값이며, 이 태그가 사라지면 확인이 풀려
+   * 서치 콘솔의 색인 요청·사이트맵 제출이 실패한다. 삭제 금지.
+   */
+  verification: {
+    google: 'DafIPWtLpIjdEIuERhMFfutDl2IoaF8b6CQTBYF6qsQ',
+    naver: 'ab246841529a97bcf76ac7ed42d5a5c457a381bc',
+  },
 } as const;
 
 /** 로케일별 기본 소셜 공유 이미지(1200×630). 썸네일이 없는 페이지의 og:image. */


### PR DESCRIPTION
# 요약
- Gatsby → Next.js 마이그레이션에서 사라진 google·naver 소유권 확인 메타 태그를 루트 레이아웃 metadata로 복구

# 배경
- 9ebe9cee(2026-07-12) 마이그레이션에서 Template.tsx에 있던 두 verification 메타 태그가 함께 제거된 뒤 복구되지 않았음
- github.io는 DNS 확인을 쓸 수 없어 메타 태그가 사실상 유일한 소유권 확인 수단인데, 태그 부재로 서치 콘솔의 색인 생성 요청과 사이트맵 제출이 실패하는 상태였음

# 영향
- 루트 `/`를 포함한 정적 페이지 154개 전체에 두 메타 태그가 출력된다
- 배포 후 서치 콘솔에서 소유권 재확인이 필요하다
- 렌더링·라우팅 동작 변화는 없다

# 테스트 시나리오
- 배포된 https://seungahhong.github.io/ 페이지 소스에 google-site-verification 메타 태그가 노출되는지 확인
- 서치 콘솔 설정 > 소유권 확인에서 확인 상태가 정상으로 표시되는지 확인
- URL 검사에서 색인 생성 요청이 에러 없이 제출되는지 확인
- 사이트맵 상태가 "가져올 수 없음"에서 정상으로 전환되는지 확인

## 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #(Isuue Number) -->

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [ ] eslint, stylelint 파일 포멧팅 검사를 수행했습니다.
