### PR TITLE
feat: 인기 글 Top 5를 GA4 실제 조회수 기준으로 전환

### DIFF
--- a/.github/workflows/refresh-popular.yml
+++ b/.github/workflows/refresh-popular.yml
@@ -1,0 +1,93 @@
+name: refresh popular posts
+
+# GA4 조회수 스냅샷(data/popular.json)을 갱신해 develop에 커밋하고, master로 가는 PR을 열어 둔다.
+# 실제 배포는 그 PR이 master에 머지될 때 deploy.yml이 수행한다.
+#
+# 필요한 시크릿
+#   GA_PROPERTY_ID          GA4 속성 ID(숫자). 측정 ID(G-...)가 아니다.
+#   GA_SERVICE_ACCOUNT_KEY  Analytics Data API 뷰어 권한이 있는 서비스 계정 JSON 키(원문 또는 base64)
+#   ACCESS_TOKEN            develop 푸시 + PR 생성용 PAT (deploy.yml과 공용)
+
+on:
+  schedule:
+    # 매일 03:00 KST (= 18:00 UTC 전날)
+    - cron: '0 18 * * *'
+  workflow_dispatch:
+    inputs:
+      range_days:
+        description: '집계 기간(일). 비우면 90일'
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: refresh-popular
+  cancel-in-progress: false
+
+jobs:
+  refresh:
+    name: Fetch GA4 pageviews → data/popular.json
+    runs-on: ubuntu-latest
+    steps:
+      - name: Git checkout (develop)
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          token: ${{ secrets.ACCESS_TOKEN }}
+
+      # 수집 스크립트는 의존성이 없다(node:crypto + fetch). pnpm install을 건너뛴다.
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Fetch pageviews
+        env:
+          GA_PROPERTY_ID: ${{ secrets.GA_PROPERTY_ID }}
+          GA_SERVICE_ACCOUNT_KEY: ${{ secrets.GA_SERVICE_ACCOUNT_KEY }}
+          GA_RANGE_DAYS: ${{ inputs.range_days }}
+        run: node scripts/fetch-popular-posts.mjs
+
+      - name: Detect changes
+        id: diff
+        run: |
+          if [ -n "$(git status --porcelain data/popular.json)" ]; then
+            echo 'changed=true' >> "$GITHUB_OUTPUT"
+          else
+            echo 'changed=false' >> "$GITHUB_OUTPUT"
+            echo '순위 변화 없음 — 커밋을 건너뜁니다.'
+          fi
+
+      - name: Commit to develop
+        if: steps.diff.outputs.changed == 'true'
+        run: |
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add data/popular.json
+          git commit -m 'chore: 인기 글 조회수 스냅샷 갱신'
+          git pull --rebase origin develop
+          git push origin HEAD:develop
+
+      - name: Open develop → master PR (없을 때만)
+        if: steps.diff.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+        run: |
+          existing=$(gh pr list --base master --head develop --state open --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            echo "이미 열린 PR #${existing}이 있어 새로 만들지 않습니다. (이번 커밋도 여기에 포함됩니다)"
+            exit 0
+          fi
+          cat > /tmp/pr-body.md <<'BODY'
+          사이드바 "Top 5 인기 글" 순위를 최신 GA4 조회수로 갱신합니다.
+
+          - 자동 생성: `.github/workflows/refresh-popular.yml`
+          - 데이터: `data/popular.json` (최근 90일, ko/en 합산 페이지뷰)
+          - 머지하면 `deploy.yml`이 빌드·배포합니다.
+          BODY
+          gh pr create --base master --head develop \
+            --title 'chore: 인기 글 조회수 스냅샷 반영' \
+            --body-file /tmp/pr-body.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,10 @@ pnpm clean
 
 # 콘텐츠 이미지 → public/blog-assets 수동 동기화
 pnpm sync:assets
+
+# GA4 조회수 → data/popular.json 갱신 (인기 글 Top 5 정렬 기준)
+# GA_PROPERTY_ID / GA_SERVICE_ACCOUNT_KEY 환경변수 필요. 평소엔 CI 크론이 실행한다.
+pnpm fetch:popular
 ```
 
 ### 코드 품질
@@ -67,6 +71,8 @@ pnpm deploy
 - `contents/` - 블로그 포스트(마크다운) 및 이미지 저장소
   - `blog/YYYY/MM/*.md` - 연/월별로 구성된 블로그 포스트
   - 영문 번역본은 `slug.en.md` 컨벤션. 번역본이 없으면 한국어 원문으로 폴백
+- `data/popular.json` - GA4 조회수 스냅샷(최근 90일, ko/en 합산). 커밋되며 빌드 시 읽는다.
+  `.github/workflows/refresh-popular.yml`(매일 03:00 KST)이 갱신하고, 없거나 비어 있으면 최신순 폴백
 - `src/app/` - Next.js App Router 라우트
   - `[lang]/` - 로케일(`ko`/`en`) 세그먼트
   - `[lang]/posts/[slug]/` - 블로그 포스트 상세

--- a/data/popular.json
+++ b/data/popular.json
@@ -1,0 +1,5 @@
+{
+  "updatedAt": null,
+  "rangeDays": 90,
+  "items": []
+}

--- a/e2e/playwright/analytics.test.ts
+++ b/e2e/playwright/analytics.test.ts
@@ -1,0 +1,24 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('google analytics (gtag.js)', () => {
+  test('loads the GA4 script on every page', async ({ page }) => {
+    await page.goto('/ko/');
+
+    await expect(
+      page.locator('script[src*="googletagmanager.com/gtag/js"]'),
+    ).toHaveCount(1);
+  });
+
+  test('does not send hits from non-production hosts', async ({ page }) => {
+    await page.goto('/ko/');
+
+    // 로컬(out/ 서빙)에서는 호스트 가드에 막혀 config 커맨드가 나가지 않아야 한다.
+    const commands = await page.evaluate(() => {
+      const dataLayer =
+        (window as unknown as { dataLayer?: IArguments[] }).dataLayer ?? [];
+      return dataLayer.map((entry) => String(entry[0]));
+    });
+
+    expect(commands).not.toContain('config');
+  });
+});

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "scripts": {
     "sync:assets": "node scripts/sync-content-assets.mjs",
+    "fetch:popular": "node scripts/fetch-popular-posts.mjs",
     "predev": "pnpm sync:assets",
     "dev": "next dev",
     "prebuild": "pnpm sync:assets",

--- a/scripts/fetch-popular-posts.mjs
+++ b/scripts/fetch-popular-posts.mjs
@@ -1,0 +1,235 @@
+// GA4 Data API에서 최근 N일 글별 페이지뷰를 받아 data/popular.json으로 굽는다.
+// 사이드바 "인기 글 Top 5"가 이 파일을 정렬 기준으로 쓴다(src/lib/popular.ts).
+//
+// - 빌드 경로에 있지 않다. 빌드는 커밋된 data/popular.json만 읽으므로 네트워크 없이도 성공한다.
+//   이 스크립트는 CI 크론(.github/workflows/refresh-popular.yml)에서만 돌고, 결과가 바뀌면 커밋된다.
+// - 공식 클라이언트(@google-analytics/data)는 gRPC/gax 의존성이 무거워 REST + JWT로 직접 호출한다.
+// - ko/en은 같은 글의 번역본이므로 슬러그 기준으로 조회수를 합산한다.
+//
+// 필요한 환경변수
+//   GA_PROPERTY_ID          GA4 속성 ID(숫자 9자리). 측정 ID(G-...)가 아니다.
+//   GA_SERVICE_ACCOUNT_KEY  서비스 계정 JSON 키. 원문 JSON 또는 base64 인코딩 모두 허용.
+//   GA_RANGE_DAYS           (선택) 집계 기간, 기본 90일.
+import { createSign } from 'node:crypto';
+import { readFile, readdir, writeFile, mkdir } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const ROOT = path.resolve(__dirname, '..');
+const CONTENT_DIR = path.join(ROOT, 'contents', 'blog');
+const OUT_FILE = path.join(ROOT, 'data', 'popular.json');
+const DEFAULT_RANGE_DAYS = 90;
+const SCOPE = 'https://www.googleapis.com/auth/analytics.readonly';
+
+/**
+ * `/ko/posts/2024-03-18-pnpm/` → `2024-03-18-pnpm`.
+ * 로케일 프리픽스·트레일링 슬래시·쿼리스트링을 모두 흡수하고, 글 상세가 아니면 null.
+ */
+export function slugFromPagePath(pagePath) {
+  const pathOnly = String(pagePath ?? '').split(/[?#]/)[0];
+  const match = /^\/(?:ko|en)\/posts\/([^/]+)\/?$/.exec(pathOnly);
+  if (!match) return null;
+  try {
+    return decodeURIComponent(match[1]);
+  } catch {
+    return match[1];
+  }
+}
+
+/**
+ * GA 행({ pagePath, views })을 슬러그 기준으로 합산한다.
+ * knownSlugs에 없는 슬러그(삭제된 글, 크롤러가 만든 유령 경로)는 버린다.
+ */
+export function aggregateViews(rows, knownSlugs) {
+  const totals = new Map();
+  for (const { pagePath, views } of rows) {
+    const slug = slugFromPagePath(pagePath);
+    if (!slug || !knownSlugs.has(slug)) continue;
+    const count = Number(views);
+    if (!Number.isFinite(count) || count <= 0) continue;
+    totals.set(slug, (totals.get(slug) ?? 0) + count);
+  }
+  return [...totals.entries()]
+    .map(([slug, views]) => ({ slug, views }))
+    .sort((a, b) => b.views - a.views || a.slug.localeCompare(b.slug));
+}
+
+/** contents/blog 하위 마크다운 파일명에서 슬러그 집합을 만든다(`.en.md` 번역본은 같은 슬러그). */
+async function collectKnownSlugs(dir = CONTENT_DIR, out = new Set()) {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return out;
+  }
+  for (const entry of entries) {
+    if (entry.isDirectory()) {
+      if (entry.name === 'assets') continue;
+      await collectKnownSlugs(path.join(dir, entry.name), out);
+    } else if (entry.isFile() && /\.md$/i.test(entry.name)) {
+      out.add(entry.name.replace(/\.md$/i, '').replace(/\.(ko|en)$/, ''));
+    }
+  }
+  return out;
+}
+
+/** base64로 감싼 시크릿도 받아 준다(깃허브 시크릿에 줄바꿈 포함 JSON을 넣기 번거로워서). */
+function parseCredentials(raw) {
+  const text = raw.startsWith('{')
+    ? raw
+    : Buffer.from(raw, 'base64').toString('utf-8');
+  const credentials = JSON.parse(text);
+  if (!credentials.client_email || !credentials.private_key) {
+    throw new Error(
+      '서비스 계정 키에 client_email 또는 private_key가 없습니다.',
+    );
+  }
+  return credentials;
+}
+
+/** 서비스 계정 JWT를 만들어 OAuth 액세스 토큰으로 교환한다. */
+async function getAccessToken(credentials) {
+  const now = Math.floor(Date.now() / 1000);
+  const encode = (value) =>
+    Buffer.from(JSON.stringify(value)).toString('base64url');
+  const unsigned = [
+    encode({ alg: 'RS256', typ: 'JWT' }),
+    encode({
+      iss: credentials.client_email,
+      scope: SCOPE,
+      aud: 'https://oauth2.googleapis.com/token',
+      iat: now,
+      exp: now + 3600,
+    }),
+  ].join('.');
+
+  const signature = createSign('RSA-SHA256')
+    .update(unsigned)
+    .sign(credentials.private_key, 'base64url');
+
+  const res = await fetch('https://oauth2.googleapis.com/token', {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'urn:ietf:params:oauth:grant-type:jwt-bearer',
+      assertion: `${unsigned}.${signature}`,
+    }),
+  });
+  if (!res.ok) {
+    throw new Error(
+      `액세스 토큰 발급 실패 (${res.status}): ${await res.text()}`,
+    );
+  }
+  return (await res.json()).access_token;
+}
+
+/** 글 상세 경로만 골라 pagePath별 페이지뷰를 받아 온다. */
+async function runReport(token, propertyId, rangeDays) {
+  const res = await fetch(
+    `https://analyticsdata.googleapis.com/v1beta/properties/${propertyId}:runReport`,
+    {
+      method: 'POST',
+      headers: {
+        authorization: `Bearer ${token}`,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        dateRanges: [{ startDate: `${rangeDays}daysAgo`, endDate: 'today' }],
+        dimensions: [{ name: 'pagePath' }],
+        metrics: [{ name: 'screenPageViews' }],
+        dimensionFilter: {
+          filter: {
+            fieldName: 'pagePath',
+            stringFilter: {
+              matchType: 'FULL_REGEXP',
+              value: '^/(ko|en)/posts/[^/]+/?$',
+            },
+          },
+        },
+        orderBys: [{ metric: { metricName: 'screenPageViews' }, desc: true }],
+        limit: 5000,
+      }),
+    },
+  );
+  if (!res.ok) {
+    throw new Error(`runReport 실패 (${res.status}): ${await res.text()}`);
+  }
+  const body = await res.json();
+  return (body.rows ?? []).map((row) => ({
+    pagePath: row.dimensionValues?.[0]?.value ?? '',
+    views: row.metricValues?.[0]?.value ?? '0',
+  }));
+}
+
+async function readExisting() {
+  try {
+    return JSON.parse(await readFile(OUT_FILE, 'utf-8'));
+  } catch {
+    return null;
+  }
+}
+
+export async function main() {
+  const propertyId = process.env.GA_PROPERTY_ID?.trim();
+  const rawKey = process.env.GA_SERVICE_ACCOUNT_KEY?.trim();
+  const rangeDays = Number(process.env.GA_RANGE_DAYS) || DEFAULT_RANGE_DAYS;
+
+  // 설정이 없는 환경(로컬·포크)에서는 커밋된 데이터를 그대로 두고 조용히 끝낸다.
+  if (!propertyId || !rawKey) {
+    console.warn(
+      '[popular] GA_PROPERTY_ID / GA_SERVICE_ACCOUNT_KEY가 없어 건너뜁니다. 기존 data/popular.json을 유지합니다.',
+    );
+    return;
+  }
+
+  const token = await getAccessToken(parseCredentials(rawKey));
+  const rows = await runReport(token, propertyId, rangeDays);
+  const knownSlugs = await collectKnownSlugs();
+  const items = aggregateViews(rows, knownSlugs);
+
+  // 조회수가 하나도 안 잡히면(계측 직후·API 이상) 기존 데이터를 덮어쓰지 않는다.
+  if (items.length === 0) {
+    console.warn(
+      `[popular] 최근 ${rangeDays}일 조회수 데이터가 비어 있어 기존 파일을 유지합니다. (GA 행 ${rows.length}건)`,
+    );
+    return;
+  }
+
+  const existing = await readExisting();
+  const unchanged =
+    existing?.rangeDays === rangeDays &&
+    JSON.stringify(existing?.items) === JSON.stringify(items);
+  if (unchanged) {
+    console.log('[popular] 변경 없음 — 파일을 그대로 둡니다.');
+    return;
+  }
+
+  await mkdir(path.dirname(OUT_FILE), { recursive: true });
+  await writeFile(
+    OUT_FILE,
+    `${JSON.stringify(
+      {
+        updatedAt: new Date().toISOString().slice(0, 10),
+        rangeDays,
+        items,
+      },
+      null,
+      2,
+    )}\n`,
+    'utf-8',
+  );
+  const total = items.reduce((sum, item) => sum + item.views, 0);
+  console.log(
+    `[popular] ${items.length}개 글 / 총 ${total} 조회수 → data/popular.json`,
+  );
+}
+
+const invokedDirectly =
+  process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href;
+if (invokedDirectly) {
+  main().catch((error) => {
+    console.error(`[popular] ${error.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/fetch-popular-posts.test.mjs
+++ b/scripts/fetch-popular-posts.test.mjs
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import { aggregateViews, slugFromPagePath } from './fetch-popular-posts.mjs';
+
+describe('slugFromPagePath', () => {
+  it('로케일 프리픽스와 트레일링 슬래시를 흡수한다', () => {
+    expect(slugFromPagePath('/ko/posts/2024-03-18-pnpm/')).toBe(
+      '2024-03-18-pnpm',
+    );
+    expect(slugFromPagePath('/en/posts/2024-03-18-pnpm')).toBe(
+      '2024-03-18-pnpm',
+    );
+  });
+
+  it('쿼리스트링과 해시를 잘라낸다', () => {
+    expect(slugFromPagePath('/ko/posts/2024-03-18-pnpm/?utm_source=x')).toBe(
+      '2024-03-18-pnpm',
+    );
+    expect(slugFromPagePath('/ko/posts/2024-03-18-pnpm/#intro')).toBe(
+      '2024-03-18-pnpm',
+    );
+  });
+
+  it('퍼센트 인코딩된 슬러그를 복원한다', () => {
+    expect(slugFromPagePath('/ko/posts/2024-03-18-pnpm%20test/')).toBe(
+      '2024-03-18-pnpm test',
+    );
+  });
+
+  it('글 상세가 아닌 경로는 null', () => {
+    expect(slugFromPagePath('/ko/posts/')).toBeNull();
+    expect(slugFromPagePath('/ko/')).toBeNull();
+    expect(slugFromPagePath('/ko/tags/?tag=react')).toBeNull();
+    expect(slugFromPagePath('/posts/2024-03-18-pnpm/')).toBeNull();
+    expect(slugFromPagePath(undefined)).toBeNull();
+  });
+});
+
+describe('aggregateViews', () => {
+  const known = new Set(['a-post', 'b-post']);
+
+  it('ko/en 조회수를 슬러그 기준으로 합산한다', () => {
+    const rows = [
+      { pagePath: '/ko/posts/a-post/', views: '10' },
+      { pagePath: '/en/posts/a-post/', views: '5' },
+      { pagePath: '/ko/posts/b-post/', views: '12' },
+    ];
+    expect(aggregateViews(rows, known)).toEqual([
+      { slug: 'a-post', views: 15 },
+      { slug: 'b-post', views: 12 },
+    ]);
+  });
+
+  it('콘텐츠에 없는 슬러그와 글 목록 경로는 버린다', () => {
+    const rows = [
+      { pagePath: '/ko/posts/deleted-post/', views: '999' },
+      { pagePath: '/ko/posts/', views: '999' },
+      { pagePath: '/ko/posts/a-post/', views: '3' },
+    ];
+    expect(aggregateViews(rows, known)).toEqual([{ slug: 'a-post', views: 3 }]);
+  });
+
+  it('조회수가 0이거나 숫자가 아니면 제외한다', () => {
+    const rows = [
+      { pagePath: '/ko/posts/a-post/', views: '0' },
+      { pagePath: '/ko/posts/b-post/', views: 'n/a' },
+    ];
+    expect(aggregateViews(rows, known)).toEqual([]);
+  });
+
+  it('동률이면 슬러그 이름순으로 안정 정렬한다', () => {
+    const rows = [
+      { pagePath: '/ko/posts/b-post/', views: '7' },
+      { pagePath: '/ko/posts/a-post/', views: '7' },
+    ];
+    expect(aggregateViews(rows, known).map((item) => item.slug)).toEqual([
+      'a-post',
+      'b-post',
+    ]);
+  });
+});

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import { ThemeProvider } from '@/components/providers/ThemeProvider';
+import GoogleAnalytics from '@/components/GoogleAnalytics';
 import { ogImagePath, siteConfig } from '@/lib/site';
 import { getDictionary } from '@/lib/i18n';
 import { defaultLocale } from '@/i18n/config';
@@ -51,6 +52,7 @@ export default function RootLayout({
     <html lang="ko" suppressHydrationWarning>
       <body>
         <ThemeProvider>{children}</ThemeProvider>
+        <GoogleAnalytics />
       </body>
     </html>
   );

--- a/src/components/GoogleAnalytics.tsx
+++ b/src/components/GoogleAnalytics.tsx
@@ -1,0 +1,41 @@
+import Script from 'next/script';
+import { siteConfig } from '@/lib/site';
+
+/** 실제 배포 호스트에서만 히트를 보낸다 — 로컬 `pnpm serve`나 E2E는 집계에서 제외. */
+const PROD_HOST = new URL(siteConfig.url).hostname;
+
+/**
+ * GA4(gtag.js) 로더.
+ *
+ * 페이지뷰를 수동으로 쏘지 않는다. GA4 향상된 측정의 "브라우저 기록 이벤트 기반
+ * 페이지 변경"이 App Router의 클라이언트 내비게이션(pushState)까지 자동으로 잡기
+ * 때문에, 여기서 page_view를 또 보내면 조회수가 두 배로 집계된다.
+ * (인기 글 정렬이 이 조회수를 기준으로 삼으므로 중복 집계는 순위를 왜곡한다)
+ */
+export default function GoogleAnalytics() {
+  // 개발 서버에서는 스크립트 자체를 싣지 않는다.
+  if (process.env.NODE_ENV !== 'production') return null;
+
+  const [loaderId] = siteConfig.gaIds;
+  const configs = siteConfig.gaIds
+    .map((id) => `  gtag('config', ${JSON.stringify(id)});`)
+    .join('\n');
+
+  return (
+    <>
+      <Script
+        id="ga4-loader"
+        strategy="afterInteractive"
+        src={`https://www.googletagmanager.com/gtag/js?id=${loaderId}`}
+      />
+      <Script id="ga4-init" strategy="afterInteractive">
+        {`window.dataLayer = window.dataLayer || [];
+window.gtag = function gtag() { window.dataLayer.push(arguments); };
+if (location.hostname === ${JSON.stringify(PROD_HOST)}) {
+  gtag('js', new Date());
+${configs}
+}`}
+      </Script>
+    </>
+  );
+}

--- a/src/components/home/Sidebar.tsx
+++ b/src/components/home/Sidebar.tsx
@@ -2,8 +2,10 @@ import Link from 'next/link';
 import { Search } from 'lucide-react';
 import type { Locale } from '@/i18n/config';
 import type { Dictionary } from '@/lib/i18n';
-import type { CategoryCount, PostMeta, TagCount } from '@/types';
+import type { CategoryCount, TagCount } from '@/types';
+import type { PopularPost } from '@/lib/popular';
 import { categoryPath, postPath, tagPath } from '@/lib/routes';
+import { formatViews } from '@/lib/site';
 import SearchTrigger from '@/components/search/SearchTrigger';
 
 function WidgetTitle({ children }: { children: React.ReactNode }) {
@@ -25,12 +27,20 @@ export default function Sidebar({
 }: {
   locale: Locale;
   dict: Dictionary;
-  popular: PostMeta[];
+  popular: PopularPost[];
   categories: CategoryCount[];
   tags: TagCount[];
   activeCategory?: string;
 }) {
   const maxPopularRank = popular.length || 1;
+  const topViews = Math.max(0, ...popular.map((post) => post.views ?? 0));
+  const barWidth = (post: PopularPost, rank: number) => {
+    // 조회수 데이터 자체가 없으면(계측 전) 예전처럼 순위로 막대를 그린다.
+    if (topViews <= 0) return 100 - (rank / maxPopularRank) * 60;
+    // 조회수가 아직 안 잡혀 최신순으로 채운 자리 — 실제 수치가 있는 글보다 항상 짧게.
+    if (post.views === null) return 12;
+    return Math.max(20, Math.round((post.views / topViews) * 100));
+  };
 
   return (
     <aside className="flex flex-col gap-7 lg:sticky lg:top-20">
@@ -64,13 +74,14 @@ export default function Sidebar({
                     {post.title}
                   </p>
                   <div className="signal-track" aria-hidden="true">
-                    <i
-                      style={{ width: `${100 - (i / maxPopularRank) * 60}%` }}
-                    />
+                    <i style={{ width: `${barWidth(post, i)}%` }} />
                   </div>
                   <p className="mt-1.5 font-mono text-[10.5px] text-faint">
                     {post.category}
                     {post.tags[0] ? ` · ${post.tags[0]}` : ''}
+                    {post.views !== null
+                      ? ` · ${formatViews(post.views, locale)} ${dict.home.views}`
+                      : ''}
                   </p>
                 </Link>
               </li>

--- a/src/i18n/dictionaries/en.json
+++ b/src/i18n/dictionaries/en.json
@@ -34,6 +34,7 @@
     "recentPosts": "Recent posts",
     "viewAll": "View all →",
     "popular": "Top 5 popular",
+    "views": "views",
     "categories": "Categories",
     "tags": "Tags"
   },

--- a/src/i18n/dictionaries/ko.json
+++ b/src/i18n/dictionaries/ko.json
@@ -34,6 +34,7 @@
     "recentPosts": "최근 글",
     "viewAll": "전체 보기 →",
     "popular": "Top 5 인기 글",
+    "views": "조회",
     "categories": "카테고리",
     "tags": "태그"
   },

--- a/src/lib/popular.test.ts
+++ b/src/lib/popular.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  clearPopularCache,
+  rankPostsByViews,
+  readPopularData,
+  type PopularData,
+} from './popular';
+import type { PostMeta } from '@/types';
+
+const tmpDirs: string[] = [];
+
+afterEach(() => {
+  clearPopularCache();
+  for (const dir of tmpDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function writeSnapshot(contents: string): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'popular-'));
+  tmpDirs.push(dir);
+  const file = path.join(dir, 'popular.json');
+  fs.writeFileSync(file, contents, 'utf-8');
+  return file;
+}
+
+/** posts는 항상 최신순으로 들어온다(getAllPosts 계약). */
+function posts(...slugs: string[]): PostMeta[] {
+  return slugs.map((slug, index) => ({
+    slug,
+    title: slug,
+    date: `2024-01-${String(slugs.length - index).padStart(2, '0')}`,
+    category: '개발',
+    tags: [],
+    thumbnail: null,
+    github: null,
+    excerpt: '',
+    readingTime: 1,
+    wordCount: 0,
+    relDir: '2024/01',
+    year: '2024',
+    contentLocale: 'ko' as const,
+  }));
+}
+
+function snapshot(items: PopularData['items']): PopularData {
+  return { updatedAt: '2026-08-01', rangeDays: 90, items };
+}
+
+describe('rankPostsByViews', () => {
+  it('조회수 내림차순으로 정렬한다', () => {
+    const ranked = rankPostsByViews(
+      posts('a', 'b', 'c'),
+      3,
+      snapshot([
+        { slug: 'a', views: 10 },
+        { slug: 'b', views: 90 },
+        { slug: 'c', views: 50 },
+      ]),
+    );
+    expect(ranked.map((post) => [post.slug, post.views])).toEqual([
+      ['b', 90],
+      ['c', 50],
+      ['a', 10],
+    ]);
+  });
+
+  it('조회수가 같으면 최신 글이 앞선다', () => {
+    const ranked = rankPostsByViews(
+      posts('newer', 'older'),
+      2,
+      snapshot([
+        { slug: 'older', views: 7 },
+        { slug: 'newer', views: 7 },
+      ]),
+    );
+    expect(ranked.map((post) => post.slug)).toEqual(['newer', 'older']);
+  });
+
+  it('조회수가 잡힌 글이 모자라면 최신순으로 자리를 채우고 views는 null', () => {
+    const ranked = rankPostsByViews(
+      posts('a', 'b', 'c'),
+      3,
+      snapshot([{ slug: 'c', views: 40 }]),
+    );
+    expect(ranked.map((post) => [post.slug, post.views])).toEqual([
+      ['c', 40],
+      ['a', null],
+      ['b', null],
+    ]);
+  });
+
+  it('스냅샷에만 있고 실제로는 없는 글은 무시한다', () => {
+    const ranked = rankPostsByViews(
+      posts('a'),
+      5,
+      snapshot([
+        { slug: 'deleted', views: 999 },
+        { slug: 'a', views: 1 },
+      ]),
+    );
+    expect(ranked.map((post) => post.slug)).toEqual(['a']);
+  });
+
+  it('데이터가 없거나 비어 있으면 전부 최신순 폴백', () => {
+    for (const data of [null, snapshot([])]) {
+      const ranked = rankPostsByViews(posts('a', 'b', 'c'), 2, data);
+      expect(ranked.map((post) => [post.slug, post.views])).toEqual([
+        ['a', null],
+        ['b', null],
+      ]);
+    }
+  });
+
+  it('count보다 글이 적어도 있는 만큼만 돌려준다', () => {
+    expect(rankPostsByViews(posts('a'), 5, null)).toHaveLength(1);
+    expect(rankPostsByViews([], 5, null)).toEqual([]);
+  });
+});
+
+describe('readPopularData', () => {
+  it('정상 스냅샷을 읽는다', () => {
+    const file = writeSnapshot(
+      JSON.stringify({
+        updatedAt: '2026-08-01',
+        rangeDays: 90,
+        items: [{ slug: 'a', views: 12 }],
+      }),
+    );
+    expect(readPopularData(file)).toEqual({
+      updatedAt: '2026-08-01',
+      rangeDays: 90,
+      items: [{ slug: 'a', views: 12 }],
+    });
+  });
+
+  it('파일이 없거나 JSON이 깨졌으면 null (최신순 폴백)', () => {
+    expect(readPopularData('/nope/popular.json')).toBeNull();
+    expect(readPopularData(writeSnapshot('{ 깨진 json'))).toBeNull();
+    expect(readPopularData(writeSnapshot('{"items":"배열아님"}'))).toBeNull();
+  });
+
+  it('망가진 항목만 걸러 내고 나머지는 살린다', () => {
+    const file = writeSnapshot(
+      JSON.stringify({
+        items: [
+          { slug: 'a', views: 5 },
+          { slug: 'b', views: '9' },
+          { slug: 'c' },
+          { views: 3 },
+          { slug: 'd', views: 0 },
+          null,
+        ],
+      }),
+    );
+    expect(readPopularData(file)?.items).toEqual([{ slug: 'a', views: 5 }]);
+  });
+
+  it('시드 상태(items: [])는 빈 목록으로 읽힌다', () => {
+    const file = writeSnapshot(
+      JSON.stringify({ updatedAt: null, rangeDays: 90, items: [] }),
+    );
+    expect(readPopularData(file)).toEqual({
+      updatedAt: null,
+      rangeDays: 90,
+      items: [],
+    });
+  });
+});

--- a/src/lib/popular.ts
+++ b/src/lib/popular.ts
@@ -1,0 +1,115 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { PostMeta } from '@/types';
+
+/**
+ * GA4 조회수 스냅샷. scripts/fetch-popular-posts.mjs가 CI 크론에서 굽고 커밋한다.
+ * 빌드는 이 파일만 읽으므로 네트워크 없이도 성공하고, 파일이 없으면 최신순으로 폴백한다.
+ */
+export const POPULAR_DATA_FILE = path.join(
+  process.cwd(),
+  'data',
+  'popular.json',
+);
+
+export interface PopularEntry {
+  slug: string;
+  /** ko/en 합산 페이지뷰 */
+  views: number;
+}
+
+export interface PopularData {
+  /** 데이터가 마지막으로 바뀐 날(YYYY-MM-DD). 아직 한 번도 수집되지 않았으면 null. */
+  updatedAt: string | null;
+  rangeDays: number;
+  items: PopularEntry[];
+}
+
+/** 인기 글 항목. views가 null이면 조회수가 없어 최신순으로 채운 자리다. */
+export interface PopularPost extends PostMeta {
+  views: number | null;
+}
+
+const cache = new Map<string, PopularData | null>();
+
+/** 손상된 필드는 통째로 버리지 않고 걸러 낸다 — 순위가 비는 것보다 낫다. */
+function parsePopularData(raw: string): PopularData | null {
+  const data: unknown = JSON.parse(raw);
+  if (typeof data !== 'object' || data === null) return null;
+  const { updatedAt, rangeDays, items } = data as Record<string, unknown>;
+  if (!Array.isArray(items)) return null;
+
+  return {
+    updatedAt: typeof updatedAt === 'string' ? updatedAt : null,
+    rangeDays: typeof rangeDays === 'number' ? rangeDays : 0,
+    items: items.flatMap((item) => {
+      if (typeof item !== 'object' || item === null) return [];
+      const { slug, views } = item as Record<string, unknown>;
+      if (typeof slug !== 'string' || typeof views !== 'number') return [];
+      if (!Number.isFinite(views) || views <= 0) return [];
+      return [{ slug, views }];
+    }),
+  };
+}
+
+/** 조회수 스냅샷을 읽는다(파일이 없거나 깨졌으면 null). 빌드 중 로케일마다 호출되므로 메모한다. */
+export function readPopularData(
+  file: string = POPULAR_DATA_FILE,
+): PopularData | null {
+  const cached = cache.get(file);
+  if (cached !== undefined) return cached;
+
+  let data: PopularData | null = null;
+  try {
+    data = parsePopularData(fs.readFileSync(file, 'utf-8'));
+  } catch {
+    data = null;
+  }
+  cache.set(file, data);
+  return data;
+}
+
+/** 테스트용 — 메모된 스냅샷을 비운다. */
+export function clearPopularCache(): void {
+  cache.clear();
+}
+
+/**
+ * 조회수 내림차순 Top N.
+ * - 동률이면 최신 글이 앞선다(posts는 이미 최신순).
+ * - 조회수가 잡힌 글이 N개보다 적으면 나머지는 최신순으로 채우고 views는 null이 된다.
+ * - 데이터 자체가 없으면 전부 최신순 — 계측 이전 상태에서도 위젯이 비지 않는다.
+ */
+export function rankPostsByViews(
+  posts: PostMeta[],
+  count: number,
+  data: PopularData | null,
+): PopularPost[] {
+  const views = new Map(data?.items.map((item) => [item.slug, item.views]));
+  const latest = (list: PostMeta[]) =>
+    list.map((post) => ({ ...post, views: null }));
+
+  if (views.size === 0) return latest(posts.slice(0, count));
+
+  const recency = new Map(posts.map((post, index) => [post.slug, index]));
+  const viewsOf = (slug: string) => views.get(slug) ?? 0;
+  const recencyOf = (slug: string) => recency.get(slug) ?? Infinity;
+
+  const ranked = posts
+    .filter((post) => views.has(post.slug))
+    .sort(
+      (a, b) =>
+        viewsOf(b.slug) - viewsOf(a.slug) ||
+        recencyOf(a.slug) - recencyOf(b.slug),
+    )
+    .slice(0, count)
+    .map((post) => ({ ...post, views: viewsOf(post.slug) }));
+
+  if (ranked.length >= count) return ranked;
+
+  const picked = new Set(ranked.map((post) => post.slug));
+  const filler = posts
+    .filter((post) => !picked.has(post.slug))
+    .slice(0, count - ranked.length);
+  return [...ranked, ...latest(filler)];
+}

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -13,6 +13,7 @@ import type {
 } from '@/types';
 import { makeExcerpt, renderMarkdown, rewriteAssetSrc } from './markdown';
 import { readingTime, wordCount } from './reading-time';
+import { rankPostsByViews, readPopularData, type PopularPost } from './popular';
 
 export const CONTENT_ROOT = path.join(process.cwd(), 'contents', 'blog');
 
@@ -274,9 +275,13 @@ export function getTagCounts(posts: PostMeta[]): TagCount[] {
 }
 
 /**
- * 인기 글 Top N. 조회수 데이터가 없는 정적 사이트라 현재는 최신순 근사치.
- * (다음 라운드에서 GA/큐레이션 데이터로 교체 예정)
+ * 인기 글 Top N. data/popular.json(GA4 ko/en 합산 조회수)의 내림차순.
+ * 조회수 데이터가 없으면 예전처럼 최신순으로 폴백한다(src/lib/popular.ts 참고).
  */
-export function getPopularPosts(posts: PostMeta[], count = 5): PostMeta[] {
-  return posts.slice(0, count);
+export function getPopularPosts(
+  posts: PostMeta[],
+  count = 5,
+  dataFile?: string,
+): PopularPost[] {
+  return rankPostsByViews(posts, count, readPopularData(dataFile));
 }

--- a/src/lib/site.ts
+++ b/src/lib/site.ts
@@ -12,7 +12,10 @@ export const siteConfig = {
     portfolio: 'https://seungah-portfolio.vercel.app',
     email: 'gmm117@naver.com',
   },
-  /** Google Analytics 측정 ID (다음 라운드에서 스크립트 연결) */
+  /**
+   * Google Analytics 측정 ID. 첫 번째 ID로 gtag.js를 불러오고 전체에 config를 보낸다.
+   * (`GoogleAnalytics` 컴포넌트 참고 — 인기 글 정렬이 이 조회수를 기준으로 한다)
+   */
   gaIds: ['G-TYGQRJE1B8', 'G-G8Z1HZWWYL'],
   /**
    * 검색 콘솔 소유권 확인 토큰.
@@ -58,6 +61,14 @@ export function coverGlyph(slug: string): string {
     hash = (hash * 17 + slug.charCodeAt(i)) >>> 0;
   }
   return GLYPHS[hash % GLYPHS.length];
+}
+
+/** 조회수 축약 표기 (1234 → ko `1.2천`, en `1.2K`) */
+export function formatViews(views: number, locale: Locale): string {
+  return new Intl.NumberFormat(locale === 'ko' ? 'ko-KR' : 'en-US', {
+    notation: 'compact',
+    maximumFractionDigits: 1,
+  }).format(views);
 }
 
 /** 로케일별 날짜 포맷 (YYYY-MM-DD → 표시용) */

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./vitest.setup.ts'],
-    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'scripts/**/*.{test,spec}.mjs'],
     exclude: ['node_modules', 'e2e', 'out', '.next'],
   },
   resolve: {


### PR DESCRIPTION
# 요약
- 최신순 근사치였던 사이드바 인기 글을 GA4 페이지뷰(최근 90일, ko/en 합산) 기준 정렬로 교체
- 마이그레이션 이후 끊겨 있던 GA4 계측을 복구하고, 조회수 스냅샷을 매일 갱신하는 CI 크론 추가

# 배경
- Gatsby → Next.js 마이그레이션 때 gtag 스크립트가 유실되어 측정 ID만 남고 실제 수집은 멈춰 있었다
- 조회수 데이터가 없어 getPopularPosts가 posts.slice(0, 5)로 최신 글을 인기 글처럼 노출하고 있었다

# 설계
- 페이지뷰는 GA4 향상된 측정에 맡기고 수동 page_view는 보내지 않는다 — 둘 다 켜면 클라이언트 내비게이션이 이중 집계되어 순위가 왜곡된다
- 조회수는 빌드 타임 스냅샷(data/popular.json)으로 커밋한다. 정적 익스포트를 유지하면서 런타임 비용 없이 순위를 반영할 수 있다
- 수집은 공식 클라이언트(@google-analytics/data) 대신 REST + node:crypto JWT로 호출한다. gRPC/gax 의존성이 배포 워크플로의 설치 시간을 매번 늘린다

# 영향
- getPopularPosts 반환 타입이 PostMeta[] → PopularPost[](views: number | null 추가)로 바뀐다
- data/popular.json이 없거나 비어 있으면 최신순으로 폴백하므로, 시크릿 등록 전에도 화면 동작은 이전과 같다
- 크론이 동작하려면 GA_PROPERTY_ID·GA_SERVICE_ACCOUNT_KEY 시크릿과 서비스 계정의 GA 속성 뷰어 권한이 필요하다
- gtag는 프로덕션 호스트에서만 config를 실행하므로 로컬·E2E 트래픽은 집계되지 않는다

# 테스트 시나리오
- 배포 후 GA4 실시간 보고서에 방문이 잡히는지 확인
- 글 사이를 클라이언트 내비게이션으로 이동했을 때 page_view가 한 번만 기록되는지 확인
- 시크릿 등록 후 워크플로를 수동 실행해 data/popular.json 갱신·develop 커밋·PR 생성이 되는지 확인
- 조회수 반영 후 사이드바 Top 5의 순서, 조회수 표기(한국어 '조회' / 영어 'views'), 막대 길이가 순위와 일치하는지 확인
- data/popular.json이 빈 상태로 빌드했을 때 최신순 5개가 조회수 없이 그대로 나오는지 확인

## 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #(Isuue Number) -->

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [ ] eslint, stylelint 파일 포멧팅 검사를 수행했습니다.
