### PR TITLE
fix: 하이드레이션 레이스로 배포를 막던 analytics E2E 수정

### DIFF
--- a/e2e/playwright/analytics.test.ts
+++ b/e2e/playwright/analytics.test.ts
@@ -1,4 +1,19 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * gtag 스크립트 태그가 DOM에 붙을 때까지 기다린다.
+ *
+ * `next/script`의 afterInteractive라 태그는 하이드레이션 이후에 주입된다. 정적 HTML에는
+ * `<link rel="preload">`만 들어 있으므로, `page.goto` 직후 DOM을 한 번만 읽으면 느린
+ * 머신에서 아무것도 못 찾는다(CPU 6배 스로틀에서 재현). 자동 재시도가 있는 로케이터
+ * 단언으로 먼저 기다린 뒤에 스냅샷을 떠야 한다.
+ */
+async function waitForGtagScripts(page: Page) {
+  await expect(
+    page.locator('script[src*="googletagmanager.com/gtag/js"]'),
+  ).toHaveCount(1);
+  await expect(page.locator('script#ga4-init')).toHaveCount(1);
+}
 
 test.describe('google analytics (gtag.js)', () => {
   test('loads the GA4 script on every page', async ({ page }) => {
@@ -11,6 +26,9 @@ test.describe('google analytics (gtag.js)', () => {
 
   test('does not send hits from non-production hosts', async ({ page }) => {
     await page.goto('/ko/');
+    // 초기화 스크립트가 실행된 뒤에 봐야 한다. 주입 전에 읽으면 dataLayer가 비어 있어
+    // 호스트 가드와 무관하게 통과해 버린다.
+    await waitForGtagScripts(page);
 
     // 로컬(out/ 서빙)에서는 호스트 가드에 막혀 config 커맨드가 나가지 않아야 한다.
     const commands = await page.evaluate(() => {
@@ -30,14 +48,15 @@ test.describe('google analytics (gtag.js)', () => {
    * 멀쩡한 ID의 히트까지 통째로 유실됐는데, 태그 존재만 보는 위 테스트는 이를 통과시켰다.
    *
    * 소스 상수가 아니라 산출물이 실제로 싣는 ID를 검사한다.
-   * 구글에 실제 요청을 보내므로, 404(=ID가 없음)만 실패로 보고 통신 자체가 실패하면
-   * 배포를 막지 않도록 건너뛴다.
+   * 구글에 실제 요청을 보내므로, 404(=ID가 없음)만 실패로 보고 그 밖의 비정상 응답이나
+   * 통신 실패는 배포를 막지 않도록 건너뛴다.
    */
   test('configured GA4 measurement IDs are alive', async ({
     page,
     request,
   }) => {
     await page.goto('/ko/');
+    await waitForGtagScripts(page);
 
     const ids = await page.evaluate(() => {
       const found = new Set<string>();
@@ -60,6 +79,7 @@ test.describe('google analytics (gtag.js)', () => {
       try {
         response = await request.get(
           `https://www.googletagmanager.com/gtag/js?id=${id}`,
+          { timeout: 15_000 },
         );
       } catch {
         test.skip(
@@ -69,11 +89,24 @@ test.describe('google analytics (gtag.js)', () => {
         return;
       }
 
+      const status = response.status();
+
+      // 삭제된 속성만이 404를 준다. 이 경우에만 배포를 막는다.
       expect(
-        response.status(),
-        `측정 ID ${id}의 gtag.js가 ${response.status()}를 반환했습니다. ` +
+        status,
+        `측정 ID ${id}의 gtag.js가 404를 반환했습니다. ` +
           '삭제된 속성이면 gtag.js가 차단되어 모든 수집이 멈춥니다.',
-      ).toBe(200);
+      ).not.toBe(404);
+
+      // 429·5xx 같은 나머지 비정상 응답은 구글 쪽 사정이므로 배포 게이트로 삼지 않는다.
+      if (status !== 200) {
+        test.skip(
+          true,
+          `측정 ID ${id}의 gtag.js가 ${status}를 반환해 검증을 건너뜁니다.`,
+        );
+        return;
+      }
+
       expect(
         response.headers()['content-type'] ?? '',
         `측정 ID ${id}의 응답이 자바스크립트가 아닙니다.`,


### PR DESCRIPTION
# 요약
- gtag 태그가 주입되기 전에 DOM을 읽어 CI에서 실패하던 analytics E2E를 고치고, 404만 배포를 막도록 단언 범위를 좁혔다

# 배경
- gtag 스크립트 태그는 next/script의 afterInteractive라 하이드레이션 이후에 주입된다. 정적 HTML에는 preload 링크만 있다
- 그런데 테스트가 page.goto 직후 page.evaluate로 DOM을 한 번만 읽어, 느린 머신에서는 빈 배열을 받아 즉시 실패했다. CPU 6·20·40배 스로틀에서 그대로 재현된다
- 이 때문에 master의 deploy 워크플로가 E2E 스텝에서 실패했고(run 30734128807, 26초만에 종료), 배포 스텝이 skipped 되면서 GA 측정 ID 수정본이 실서비스에 올라가지 못했다
- does not send hits from non-production hosts도 같은 레이스가 있었다. 주입 전에 dataLayer를 읽으면 항상 비어 있어 호스트 가드가 망가져도 통과하는 상태였다
- 측정 ID 생존 검사는 주석에 "404만 실패로 본다"고 적어 두고 실제로는 toBe(200)이라, 구글이 429나 5xx를 주면 멀쩡한 ID인데도 배포가 막히는 구조였다

# 영향
- 배포 게이트가 하이드레이션 속도와 구글 응답 변덕에 좌우되지 않는다
- 삭제된 측정 ID를 잡는 원래 목적은 그대로다. 404는 여전히 실패로 배포를 막는다
- 호스트 가드 테스트가 무의미하게 통과하던 문제도 함께 해소된다

# 테스트 시나리오
- CI=true 전체 E2E 28개 통과
- CPU 6·20·40배 스로틀에서 수정 전 로직은 ids=[]로 실패, 수정 후 로직은 G-G8Z1HZWWYL을 찾는 것 확인
- gaIds에 삭제된 G-TYGQRJE1B8을 넣고 빌드하면 "Expected: not 404"으로 실패하는 것 확인 후 원복
- lint / typecheck 통과

## 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #(Isuue Number) -->

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [ ] eslint, stylelint 파일 포멧팅 검사를 수행했습니다.
