### PR TITLE
fix: 사이트맵과 어긋나던 canonical과 특수문자 슬러그 soft 404 수정

### DIFF
--- a/e2e/playwright/seo.test.ts
+++ b/e2e/playwright/seo.test.ts
@@ -1,0 +1,94 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { test, expect } from '@playwright/test';
+import type { APIRequestContext } from '@playwright/test';
+
+const SITE_ORIGIN = 'https://seungahhong.github.io';
+const OUT_DIR = path.join(process.cwd(), 'out');
+
+/** 사이트맵의 <loc> 목록(배포 절대 URL). */
+async function sitemapLocs(request: APIRequestContext): Promise<string[]> {
+  const response = await request.get('/sitemap.xml');
+  expect(response.status()).toBe(200);
+  const xml = await response.text();
+  return [...xml.matchAll(/<loc>([^<]+)<\/loc>/g)].map((match) => match[1]);
+}
+
+/**
+ * 사이트맵 URL이 가리키는 페이지의 HTML.
+ *
+ * 로컬 정적 서버(`serve`)는 `2025-06-29-vite6.0/`처럼 이름에 `.`이 든 디렉토리에서
+ * index.html 대신 디렉토리 목록을 돌려주고, index.html을 직접 요청하면 다시
+ * 디렉토리로 301을 준다. GitHub Pages는 이 주소를 정상 서빙하므로(배포본에서 확인)
+ * 서버가 목록을 준 경우에만 익스포트 산출물을 파일로 직접 읽어 검사한다.
+ */
+async function fetchPageHtml(
+  request: APIRequestContext,
+  loc: string,
+): Promise<{ status: number; html: string }> {
+  const pathname = loc.replace(SITE_ORIGIN, '');
+  const response = await request.get(pathname);
+  const html = await response.text();
+  if (!html.includes('<title>Files within')) {
+    return { status: response.status(), html };
+  }
+  const file = path.join(OUT_DIR, pathname, 'index.html');
+  if (!fs.existsSync(file)) return { status: 404, html: '' };
+  return { status: 200, html: fs.readFileSync(file, 'utf8') };
+}
+
+/**
+ * 사이트맵 URL과 canonical이 어긋나면 크롤러 입장에선 사이트맵의 모든 주소가
+ * "리다이렉트되는 URL"이 된다(GitHub Pages는 슬래시 없는 주소를 301로 넘긴다).
+ * 실제 익스포트 산출물로 두 값이 문자 단위로 같은지 확인한다.
+ */
+test.describe('sitemap ↔ canonical 정합성', () => {
+  test('사이트맵의 모든 URL이 슬래시로 끝난다', async ({ request }) => {
+    const locs = await sitemapLocs(request);
+    expect(locs.length).toBeGreaterThan(0);
+    expect(locs.filter((loc) => !loc.endsWith('/'))).toEqual([]);
+  });
+
+  test('모든 사이트맵 URL의 canonical이 <loc>과 정확히 일치한다', async ({
+    request,
+  }) => {
+    const locs = await sitemapLocs(request);
+    const mismatched: string[] = [];
+
+    for (const loc of locs) {
+      const { status, html } = await fetchPageHtml(request, loc);
+      if (status !== 200) {
+        mismatched.push(`${loc} → HTTP ${status}`);
+        continue;
+      }
+      const canonical = html.match(/<link rel="canonical" href="([^"]+)"/)?.[1];
+      if (canonical !== loc) {
+        mismatched.push(`${loc} → canonical=${canonical ?? '(없음)'}`);
+      }
+    }
+
+    expect(mismatched).toEqual([]);
+  });
+
+  /**
+   * 슬러그가 라우트 파라미터로 오갈 때 인코딩이 어긋나면 페이지는 200을 주면서
+   * not-found 본문을 렌더한다(soft 404). 그러면 제목·canonical이 레이아웃 기본값으로
+   * 떨어지므로, 특수문자가 든 슬러그가 실제 글로 렌더되는지 직접 확인한다.
+   */
+  test('특수문자·점이 든 슬러그도 실제 글로 렌더된다', async ({ request }) => {
+    const cases = [
+      { slug: '2020-02-17-c-c++', title: 'C/C++' },
+      { slug: '2025-06-29-vite6.0', title: 'Vite 6.0' },
+    ];
+
+    for (const { slug, title } of cases) {
+      const loc = `${SITE_ORIGIN}/ko/posts/${slug}/`;
+      const { status, html } = await fetchPageHtml(request, loc);
+      expect(status, `${slug} 응답 상태`).toBe(200);
+      expect(html, `${slug} 제목`).toContain(`<title>${title} · `);
+      expect(html, `${slug} canonical`).toContain(
+        `<link rel="canonical" href="${loc}"/>`,
+      );
+    }
+  });
+});

--- a/src/app/[lang]/layout.tsx
+++ b/src/app/[lang]/layout.tsx
@@ -7,7 +7,7 @@ import SearchProvider from '@/components/search/SearchProvider';
 import { getAllPosts } from '@/lib/posts';
 import { getDictionary } from '@/lib/i18n';
 import { isLocale, locales, localeHtmlLang, type Locale } from '@/i18n/config';
-import { localePath, metadataAlternates } from '@/lib/routes';
+import { absoluteUrl, localePath, metadataAlternates } from '@/lib/routes';
 import { ogImagePath } from '@/lib/site';
 
 export function generateStaticParams() {
@@ -45,7 +45,7 @@ export async function generateMetadata({
       title: dict.meta.siteTitle,
       description: dict.meta.siteDescription,
       locale: localeHtmlLang[locale],
-      url: localePath(locale),
+      url: absoluteUrl(localePath(locale)),
       images: [ogImage],
     },
     twitter: {

--- a/src/app/[lang]/posts/[slug]/page.tsx
+++ b/src/app/[lang]/posts/[slug]/page.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/lib/posts';
 import { locales, localeHtmlLang } from '@/i18n/config';
 import { ogImagePath, siteConfig } from '@/lib/site';
-import { postPath } from '@/lib/routes';
+import { absoluteUrl, decodeSlugParam, postPath } from '@/lib/routes';
 import { blogPostingJsonLd, breadcrumbJsonLd } from '@/lib/jsonld';
 import JsonLd from '@/components/JsonLd';
 import PostHeader from '@/components/post/PostHeader';
@@ -30,7 +30,8 @@ export async function generateMetadata({
 }: {
   params: PostParams;
 }): Promise<Metadata> {
-  const { lang, slug } = await params;
+  const { lang, slug: slugParam } = await params;
+  const slug = decodeSlugParam(slugParam);
   const locale = resolveLocale(lang);
   const meta = getPostMeta(slug, locale);
   if (!meta) return {};
@@ -42,12 +43,14 @@ export async function generateMetadata({
     description: meta.excerpt,
     keywords: meta.tags,
     authors: [{ name: dict.meta.author, url: siteConfig.social.portfolio }],
+    // 상대 경로를 넘기면 `2025-06-29-vite6.0`처럼 `.`이 든 슬러그에서 Next가 끝의 `/`를
+    // 생략해 사이트맵·실제 서빙 URL과 어긋난다. absoluteUrl로 형태를 고정한다.
     alternates: {
-      canonical: postPath(locale, slug),
+      canonical: absoluteUrl(postPath(locale, slug)),
       languages: {
-        ko: postPath('ko', slug),
-        en: postPath('en', slug),
-        'x-default': postPath('ko', slug),
+        ko: absoluteUrl(postPath('ko', slug)),
+        en: absoluteUrl(postPath('en', slug)),
+        'x-default': absoluteUrl(postPath('ko', slug)),
       },
     },
     openGraph: {
@@ -55,7 +58,7 @@ export async function generateMetadata({
       title: meta.title,
       description: meta.excerpt,
       locale: localeHtmlLang[locale],
-      url: postPath(locale, slug),
+      url: absoluteUrl(postPath(locale, slug)),
       publishedTime: meta.date,
       modifiedTime: meta.date,
       authors: [siteConfig.social.portfolio],
@@ -73,7 +76,8 @@ export async function generateMetadata({
 }
 
 export default async function PostPage({ params }: { params: PostParams }) {
-  const { lang, slug } = await params;
+  const { lang, slug: slugParam } = await params;
+  const slug = decodeSlugParam(slugParam);
   const locale = resolveLocale(lang);
   const post = await getPostBySlug(slug, locale);
   if (!post) notFound();

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,8 +1,7 @@
 import type { MetadataRoute } from 'next';
 import { getAllPosts, getAllSlugs, getPostMeta } from '@/lib/posts';
 import { locales } from '@/i18n/config';
-import { absoluteUrl } from '@/lib/jsonld';
-import { localePath, postPath } from '@/lib/routes';
+import { absoluteUrl, localePath, postPath } from '@/lib/routes';
 
 export const dynamic = 'force-static';
 

--- a/src/lib/jsonld.ts
+++ b/src/lib/jsonld.ts
@@ -2,17 +2,9 @@ import { localeHtmlLang, type Locale } from '@/i18n/config';
 import type { Dictionary } from '@/lib/i18n';
 import type { PostMeta } from '@/types';
 import { ogImagePath, siteConfig } from '@/lib/site';
-import { localePath, postPath } from '@/lib/routes';
+import { absoluteUrl, localePath, postPath } from '@/lib/routes';
 
 type JsonLdObject = Record<string, unknown>;
-
-/** siteConfig.url 기준 절대 URL (trailingSlash: true에 맞춰 끝에 `/` 보장). */
-export function absoluteUrl(pathname: string): string {
-  const clean = pathname.startsWith('/') ? pathname : `/${pathname}`;
-  const withSlash =
-    clean === '/' ? '/' : clean.endsWith('/') ? clean : `${clean}/`;
-  return `${siteConfig.url}${withSlash}`;
-}
 
 /** 이미지 경로를 절대 URL로 변환한다(외부 URL은 그대로, 없으면 로케일 기본 OG 이미지). */
 function absoluteImage(thumbnail: string | null, locale: Locale): string {

--- a/src/lib/metadata.ts
+++ b/src/lib/metadata.ts
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { localeHtmlLang, type Locale } from '@/i18n/config';
 import { getDictionary } from '@/lib/i18n';
-import { localePath, metadataAlternates } from '@/lib/routes';
+import { absoluteUrl, localePath, metadataAlternates } from '@/lib/routes';
 import { ogImagePath } from '@/lib/site';
 
 /**
@@ -44,7 +44,7 @@ export function sectionMetadata({
       title,
       description,
       locale: localeHtmlLang[locale],
-      url: localePath(locale, sub),
+      url: absoluteUrl(localePath(locale, sub)),
       images: [image],
     },
     twitter: {

--- a/src/lib/routes.test.ts
+++ b/src/lib/routes.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import {
+  absoluteUrl,
+  decodeSlugParam,
+  localePath,
+  metadataAlternates,
+  postPath,
+} from '@/lib/routes';
+import { siteConfig } from '@/lib/site';
+
+describe('absoluteUrl', () => {
+  it('trailingSlash 설정에 맞춰 끝에 / 를 붙인다', () => {
+    expect(absoluteUrl('/ko')).toBe(`${siteConfig.url}/ko/`);
+    expect(absoluteUrl('/ko/posts')).toBe(`${siteConfig.url}/ko/posts/`);
+  });
+
+  it('이미 / 로 끝나면 중복해서 붙이지 않는다', () => {
+    expect(absoluteUrl('/ko/')).toBe(`${siteConfig.url}/ko/`);
+    expect(absoluteUrl('/')).toBe(`${siteConfig.url}/`);
+  });
+
+  it('마지막 세그먼트에 . 이 있어도 파일로 보지 않고 / 를 붙인다', () => {
+    // Next의 상대 URL 해석은 `vite6.0`을 파일 확장자로 보고 / 를 생략한다.
+    // 사이트맵 <loc>과 canonical이 어긋나면 리다이렉트되는 URL이 되므로 여기서 형태를 고정한다.
+    expect(absoluteUrl(postPath('ko', '2025-06-29-vite6.0'))).toBe(
+      `${siteConfig.url}/ko/posts/2025-06-29-vite6.0/`,
+    );
+  });
+});
+
+describe('metadataAlternates', () => {
+  it('canonical과 hreflang을 사이트맵과 같은 절대 URL 형태로 만든다', () => {
+    const alternates = metadataAlternates('ko', '/posts');
+    expect(alternates.canonical).toBe(absoluteUrl(localePath('ko', '/posts')));
+    expect(alternates.languages.ko).toBe(`${siteConfig.url}/ko/posts/`);
+    expect(alternates.languages.en).toBe(`${siteConfig.url}/en/posts/`);
+    expect(alternates.languages['x-default']).toBe(
+      `${siteConfig.url}/ko/posts/`,
+    );
+  });
+
+  it('모든 URL이 / 로 끝난다', () => {
+    for (const sub of ['', '/posts', '/tags', '/about']) {
+      const { canonical, languages } = metadataAlternates('en', sub);
+      for (const url of [canonical, ...Object.values(languages)]) {
+        expect(url.endsWith('/')).toBe(true);
+      }
+    }
+  });
+});
+
+describe('decodeSlugParam', () => {
+  it('퍼센트 인코딩된 라우트 파라미터를 파일 슬러그로 되돌린다', () => {
+    // 정적 익스포트에서 페이지 컴포넌트에는 인코딩된 값이 들어온다.
+    expect(decodeSlugParam('2020-02-17-c-c%2B%2B')).toBe('2020-02-17-c-c++');
+  });
+
+  it('이미 디코딩된 슬러그는 그대로 둔다(generateMetadata 경로)', () => {
+    expect(decodeSlugParam('2020-02-17-c-c++')).toBe('2020-02-17-c-c++');
+    expect(decodeSlugParam('2025-06-29-vite6.0')).toBe('2025-06-29-vite6.0');
+  });
+
+  it('잘못된 퍼센트 시퀀스는 예외 없이 원본을 돌려준다', () => {
+    expect(decodeSlugParam('100%-broken')).toBe('100%-broken');
+  });
+});

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -1,4 +1,29 @@
 import type { Locale } from '@/i18n/config';
+import { siteConfig } from '@/lib/site';
+
+/** siteConfig.url 기준 절대 URL (trailingSlash: true에 맞춰 끝에 `/` 보장). */
+export function absoluteUrl(pathname: string): string {
+  const clean = pathname.startsWith('/') ? pathname : `/${pathname}`;
+  const withSlash =
+    clean === '/' ? '/' : clean.endsWith('/') ? clean : `${clean}/`;
+  return `${siteConfig.url}${withSlash}`;
+}
+
+/**
+ * 라우트 파라미터로 들어온 슬러그를 콘텐츠 슬러그로 되돌린다.
+ * 정적 익스포트에서 `2020-02-17-c-c++`처럼 특수문자가 든 슬러그는
+ * 페이지 컴포넌트에 퍼센트 인코딩된 채(`...c-c%2B%2B`) 들어오는 반면
+ * `generateMetadata`에는 디코딩된 채 들어온다. 양쪽에서 이 함수를 거치면
+ * 어느 쪽이든 파일 슬러그와 같은 문자열이 된다.
+ */
+export function decodeSlugParam(slug: string): string {
+  try {
+    return decodeURIComponent(slug);
+  } catch {
+    // 잘못된 퍼센트 시퀀스면 원본을 그대로 쓴다(어차피 조회에 실패해 404).
+    return slug;
+  }
+}
 
 /** `/ko`, `/en/posts` 같은 로케일 프리픽스 경로를 만든다. */
 export function localePath(locale: Locale, sub = ''): string {
@@ -24,14 +49,21 @@ export function swapLocaleInPath(pathname: string, target: Locale): string {
   return `/${target}${rest || ''}`;
 }
 
-/** 페이지별 canonical + hreflang alternates (섹션 경로 sub 예: '/posts'). */
+/**
+ * 페이지별 canonical + hreflang alternates (섹션 경로 sub 예: '/posts').
+ *
+ * 상대 경로를 넘기면 Next가 metadataBase에 붙이면서 마지막 세그먼트에 `.`이 있는 경로
+ * (`.../2025-06-29-vite6.0`)를 파일로 보고 끝의 `/`를 생략한다. 그러면 실제 서빙 URL·
+ * 사이트맵(`.../vite6.0/`)과 canonical이 어긋나 리다이렉트되는 URL이 된다.
+ * 그래서 여기서 `absoluteUrl`로 끝의 `/`까지 확정한 절대 URL을 넘긴다.
+ */
 export function metadataAlternates(locale: Locale, sub = '') {
   return {
-    canonical: localePath(locale, sub),
+    canonical: absoluteUrl(localePath(locale, sub)),
     languages: {
-      ko: localePath('ko', sub),
-      en: localePath('en', sub),
-      'x-default': localePath('ko', sub),
+      ko: absoluteUrl(localePath('ko', sub)),
+      en: absoluteUrl(localePath('en', sub)),
+      'x-default': absoluteUrl(localePath('ko', sub)),
     },
   };
 }


### PR DESCRIPTION
# 요약
- canonical·hreflang·og:url을 상대 경로 대신 절대 URL로 넘겨 사이트맵 <loc>과 문자 단위로 일치시킴
- 라우트 파라미터로 들어온 슬러그를 decodeSlugParam으로 정규화해 특수문자 글이 본문 대신 not-found를 렌더하던 문제 수정

# 배경
- Next는 상대 경로를 metadataBase에 붙일 때 마지막 세그먼트에 `.`이 있으면(`.../2025-06-29-vite6.0`) 파일로 보고 끝의 `/`를 생략한다. 그 결과 canonical이 사이트맵·실제 서빙 URL과 달라져 크롤러에겐 "리다이렉트되는 URL"이 된다
- 정적 익스포트에서 `2020-02-17-c-c++` 같은 슬러그는 페이지 컴포넌트에는 퍼센트 인코딩된 채, generateMetadata에는 디코딩된 채 들어와 조회에 실패했다

# 설계
- absoluteUrl을 jsonld.ts에서 routes.ts로 옮겨 URL 생성 책임을 한곳으로 모음(사이트맵·메타데이터·JSON-LD가 같은 함수를 공유)

# 영향
- absoluteUrl의 import 경로가 `@/lib/jsonld` → `@/lib/routes`로 변경됨
- canonical/hreflang/og:url이 상대 경로에서 절대 URL로 바뀜(값 자체는 기존 서빙 주소와 동일)

# 테스트 시나리오
- 사이트맵의 모든 <loc>이 슬래시로 끝나고 해당 페이지 canonical과 정확히 일치하는지 확인
- `/ko/posts/2020-02-17-c-c++/`, `/ko/posts/2025-06-29-vite6.0/`이 not-found가 아닌 실제 글로 렌더되는지 확인
- ko/en 글 상세와 목록 페이지의 hreflang·og:url이 절대 URL로 출력되는지 확인

## 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #(Isuue Number) -->

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [ ] eslint, stylelint 파일 포멧팅 검사를 수행했습니다.
