### PR TITLE
chore: 인기 글 조회수 스냅샷 반영

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,18 @@ jobs:
       - name: E2E tests (Playwright)
         run: pnpm e2e
 
+      # 실패한 E2E를 로컬에서 재현할 수 있도록 리포트와 트레이스를 남긴다.
+      # (잡 로그 다운로드는 저장소 admin 권한이 필요해 협업자가 볼 수 없다)
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 14
+
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:

--- a/.github/workflows/refresh-popular.yml
+++ b/.github/workflows/refresh-popular.yml
@@ -1,17 +1,19 @@
 name: refresh popular posts
 
-# GA4 조회수 스냅샷(data/popular.json)을 갱신해 develop에 커밋하고, master로 가는 PR을 열어 둔다.
-# 실제 배포는 그 PR이 master에 머지될 때 deploy.yml이 수행한다.
+# GA4 조회수 스냅샷(data/popular.json)을 갱신해 master에 직접 커밋한다.
+# master push가 deploy.yml을 깨우므로, 사이드바 "Top 5 인기 글"이 그대로 배포까지 반영된다.
+# develop은 건드리지 않는다 — 작업 중인 브랜치를 크론이 배포로 밀어내지 않기 위해서다.
 #
 # 필요한 시크릿
 #   GA_PROPERTY_ID          GA4 속성 ID(숫자). 측정 ID(G-...)가 아니다.
 #   GA_SERVICE_ACCOUNT_KEY  Analytics Data API 뷰어 권한이 있는 서비스 계정 JSON 키(원문 또는 base64)
-#   ACCESS_TOKEN            develop 푸시 + PR 생성용 PAT (deploy.yml과 공용)
+#   ACCESS_TOKEN            master 푸시용 PAT (deploy.yml과 공용).
+#                           기본 GITHUB_TOKEN으로 푸시하면 deploy.yml이 트리거되지 않아 배포가 멈춘다.
 
 on:
   schedule:
-    # 매일 03:00 KST (= 18:00 UTC 전날)
-    - cron: '0 18 * * *'
+    # 매일 07:00 KST (= 22:00 UTC 전날)
+    - cron: '0 22 * * *'
   workflow_dispatch:
     inputs:
       range_days:
@@ -21,7 +23,6 @@ on:
 
 permissions:
   contents: write
-  pull-requests: write
 
 concurrency:
   group: refresh-popular
@@ -32,10 +33,10 @@ jobs:
     name: Fetch GA4 pageviews → data/popular.json
     runs-on: ubuntu-latest
     steps:
-      - name: Git checkout (develop)
+      - name: Git checkout (master)
         uses: actions/checkout@v4
         with:
-          ref: develop
+          ref: master
           token: ${{ secrets.ACCESS_TOKEN }}
 
       # 수집 스크립트는 의존성이 없다(node:crypto + fetch). pnpm install을 건너뛴다.
@@ -61,33 +62,13 @@ jobs:
             echo '순위 변화 없음 — 커밋을 건너뜁니다.'
           fi
 
-      - name: Commit to develop
+      # 이 푸시가 deploy.yml(on: push → master)을 깨워 빌드·배포까지 이어진다.
+      - name: Commit to master
         if: steps.diff.outputs.changed == 'true'
         run: |
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git add data/popular.json
           git commit -m 'chore: 인기 글 조회수 스냅샷 갱신'
-          git pull --rebase origin develop
-          git push origin HEAD:develop
-
-      - name: Open develop → master PR (없을 때만)
-        if: steps.diff.outputs.changed == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-        run: |
-          existing=$(gh pr list --base master --head develop --state open --json number --jq '.[0].number')
-          if [ -n "$existing" ]; then
-            echo "이미 열린 PR #${existing}이 있어 새로 만들지 않습니다. (이번 커밋도 여기에 포함됩니다)"
-            exit 0
-          fi
-          cat > /tmp/pr-body.md <<'BODY'
-          사이드바 "Top 5 인기 글" 순위를 최신 GA4 조회수로 갱신합니다.
-
-          - 자동 생성: `.github/workflows/refresh-popular.yml`
-          - 데이터: `data/popular.json` (최근 90일, ko/en 합산 페이지뷰)
-          - 머지하면 `deploy.yml`이 빌드·배포합니다.
-          BODY
-          gh pr create --base master --head develop \
-            --title 'chore: 인기 글 조회수 스냅샷 반영' \
-            --body-file /tmp/pr-body.md
+          git pull --rebase origin master
+          git push origin HEAD:master

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,8 @@
 - `contents/blog/YYYY/MM/*.md` - 연/월별로 구성된 블로그 포스트
 - 영문 번역본은 `slug.en.md` 컨벤션. 번역본이 없으면 한국어 원문으로 폴백
 - `data/popular.json` - GA4 조회수 스냅샷(최근 90일, ko/en 합산). 커밋되며 빌드 시 읽는다.
-  `.github/workflows/refresh-popular.yml`(매일 03:00 KST)이 갱신하고, 없거나 비어 있으면 최신순 폴백
+  `.github/workflows/refresh-popular.yml`(매일 07:00 KST)이 갱신하고, 없거나 비어 있으면 최신순 폴백.
+  이 크론만은 `master`에 직접 커밋한다(아래 배포 특이사항 참고)
 
 ## 비표준 명령어
 
@@ -26,5 +27,8 @@ pnpm fetch:popular
 - 정적 익스포트 제약 때문에 태그 페이지는 per-tag 정적 라우트 대신 쿼리 기반 클라이언트 필터 사용(한글 디렉토리명 익스포트 리스크 회피)
 - 배포 경로는 `develop` → `master` 머지 → `.github/workflows/deploy.yml` → `gh-pages` 브랜치.
   GitHub Pages가 서빙하는 것은 `gh-pages`다. `pnpm deploy`는 CI를 건너뛰는 수동 폴백이다
+- 예외로 `refresh-popular.yml`은 `master`에 `data/popular.json`만 직접 커밋한다(develop 경유 안 함).
+  크론이 작업 중인 `develop`을 배포로 밀어내지 않게 하려는 것이다. 대신 `develop`의 스냅샷은
+  뒤처지므로, `develop`에서 `pnpm fetch:popular`를 돌려 커밋하면 머지 때 충돌할 수 있다
 - Gatsby 시절 주소(`/blog/<연>/<월>/<슬러그>/`, `/about/`)는 `src/lib/legacy-urls.ts` 기준으로
   canonical 스텁을 익스포트해 새 주소로 합친다. 정적 호스팅이라 301을 쓸 수 없어서다

--- a/data/popular.json
+++ b/data/popular.json
@@ -1,5 +1,54 @@
 {
-  "updatedAt": null,
+  "updatedAt": "2026-08-10",
   "rangeDays": 90,
-  "items": []
+  "items": [
+    {
+      "slug": "2026-08-01-choosing-claude-model",
+      "views": 6
+    },
+    {
+      "slug": "2026-07-31-context-engineering-claude5",
+      "views": 5
+    },
+    {
+      "slug": "2026-06-01-RAG",
+      "views": 3
+    },
+    {
+      "slug": "2026-06-02-LLM-WIKI",
+      "views": 3
+    },
+    {
+      "slug": "2026-07-13-vite8.0",
+      "views": 3
+    },
+    {
+      "slug": "2025-06-29-vite6.0",
+      "views": 2
+    },
+    {
+      "slug": "2026-07-05-meta-harness",
+      "views": 2
+    },
+    {
+      "slug": "2022-01-08-webassembly",
+      "views": 1
+    },
+    {
+      "slug": "2025-09-07-vite7.0",
+      "views": 1
+    },
+    {
+      "slug": "2026-06-03-claude-marketplace",
+      "views": 1
+    },
+    {
+      "slug": "2026-06-04-fe-harness",
+      "views": 1
+    },
+    {
+      "slug": "2026-07-12-product-spec-harness",
+      "views": 1
+    }
+  ]
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,7 +15,20 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   workers: process.env.CI ? 2 : 4,
-  reporter: process.env.CI ? 'line' : 'list',
+  /**
+   * CI에서 한 번 재시도한다. 감추기 위해서가 아니라 가르기 위해서다 —
+   * 재시도로 통과하면 Playwright가 flaky로 따로 표시해 주고, 진짜로 깨진
+   * 테스트는 두 번 다 실패해 그대로 배포를 막는다.
+   */
+  retries: process.env.CI ? 1 : 0,
+  /**
+   * `line`만 쓰면 실패한 테스트 이름이 잡 로그 안에만 남아, 로그 열람 권한이
+   * 없으면 무엇이 깨졌는지 알 수 없다(실제로 겪었다). `github` 리포터가
+   * 실패를 파일·라인 주석으로 올려 주고, `html`은 아티팩트로 올려 재현에 쓴다.
+   */
+  reporter: process.env.CI
+    ? [['github'], ['line'], ['html', { open: 'never' }]]
+    : 'list',
   use: {
     baseURL,
     trace: 'retain-on-failure',


### PR DESCRIPTION
사이드바 "Top 5 인기 글" 순위를 최신 GA4 조회수로 갱신합니다.

- 자동 생성: `.github/workflows/refresh-popular.yml`
- 데이터: `data/popular.json` (최근 90일, ko/en 합산 페이지뷰)
- 머지하면 `deploy.yml`이 빌드·배포합니다.
