### PR TITLE
fix: 인기 글 순서를 popular.json에 적힌 그대로 노출

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,7 @@
 - `contents/blog/YYYY/MM/*.md` - 연/월별로 구성된 블로그 포스트
 - 영문 번역본은 `slug.en.md` 컨벤션. 번역본이 없으면 한국어 원문으로 폴백
 - `data/popular.json` - GA4 조회수 스냅샷(최근 90일, ko/en 합산). 커밋되며 빌드 시 읽는다.
+  `items` 배열 순서가 곧 Top 5 노출 순서다 — 빌드는 재정렬하지 않으니 정렬은 수집 스크립트 책임.
   `.github/workflows/refresh-popular.yml`(매일 07:00 KST)이 갱신하고, 없거나 비어 있으면 최신순 폴백.
   이 크론만은 `master`에 직접 커밋한다(아래 배포 특이사항 참고)
 

--- a/src/lib/__test__/popular.test.ts
+++ b/src/lib/__test__/popular.test.ts
@@ -51,7 +51,8 @@ function snapshot(items: PopularData['items']): PopularData {
 }
 
 describe('rankPostsByViews', () => {
-  it('조회수 내림차순으로 정렬한다', () => {
+  it('스냅샷에 적힌 순서를 그대로 따른다(재정렬하지 않는다)', () => {
+    // 조회수가 오름차순으로 적혀 있어도 손대지 않는다 — items 배열이 곧 순위다.
     const ranked = rankPostsByViews(
       posts('a', 'b', 'c'),
       3,
@@ -62,13 +63,13 @@ describe('rankPostsByViews', () => {
       ]),
     );
     expect(ranked.map((post) => [post.slug, post.views])).toEqual([
+      ['a', 10],
       ['b', 90],
       ['c', 50],
-      ['a', 10],
     ]);
   });
 
-  it('조회수가 같으면 최신 글이 앞선다', () => {
+  it('조회수가 같아도 스냅샷 순서가 최신순을 이긴다', () => {
     const ranked = rankPostsByViews(
       posts('newer', 'older'),
       2,
@@ -77,7 +78,23 @@ describe('rankPostsByViews', () => {
         { slug: 'newer', views: 7 },
       ]),
     );
-    expect(ranked.map((post) => post.slug)).toEqual(['newer', 'older']);
+    expect(ranked.map((post) => post.slug)).toEqual(['older', 'newer']);
+  });
+
+  it('같은 슬러그가 두 번 적혀 있어도 한 번만 넣는다', () => {
+    const ranked = rankPostsByViews(
+      posts('a', 'b'),
+      2,
+      snapshot([
+        { slug: 'a', views: 9 },
+        { slug: 'a', views: 9 },
+        { slug: 'b', views: 4 },
+      ]),
+    );
+    expect(ranked.map((post) => [post.slug, post.views])).toEqual([
+      ['a', 9],
+      ['b', 4],
+    ]);
   });
 
   it('조회수가 잡힌 글이 모자라면 최신순으로 자리를 채우고 views는 null', () => {

--- a/src/lib/popular.ts
+++ b/src/lib/popular.ts
@@ -75,8 +75,10 @@ export function clearPopularCache(): void {
 }
 
 /**
- * 조회수 내림차순 Top N.
- * - 동률이면 최신 글이 앞선다(posts는 이미 최신순).
+ * 스냅샷에 적힌 순서 그대로 Top N.
+ * - items 배열이 곧 순위다. 여기서 다시 정렬하지 않는다 —
+ *   scripts/fetch-popular-posts.mjs가 조회수 내림차순(동률은 슬러그순)으로 굽고,
+ *   그 순서가 화면 순서와 어긋나지 않게 하려는 것이다.
  * - 조회수가 잡힌 글이 N개보다 적으면 나머지는 최신순으로 채우고 views는 null이 된다.
  * - 데이터 자체가 없으면 전부 최신순 — 계측 이전 상태에서도 위젯이 비지 않는다.
  */
@@ -85,25 +87,22 @@ export function rankPostsByViews(
   count: number,
   data: PopularData | null,
 ): PopularPost[] {
-  const views = new Map(data?.items.map((item) => [item.slug, item.views]));
   const latest = (list: PostMeta[]) =>
     list.map((post) => ({ ...post, views: null }));
 
-  if (views.size === 0) return latest(posts.slice(0, count));
+  const items = data?.items ?? [];
+  if (items.length === 0) return latest(posts.slice(0, count));
 
-  const recency = new Map(posts.map((post, index) => [post.slug, index]));
-  const viewsOf = (slug: string) => views.get(slug) ?? 0;
-  const recencyOf = (slug: string) => recency.get(slug) ?? Infinity;
-
-  const ranked = posts
-    .filter((post) => views.has(post.slug))
-    .sort(
-      (a, b) =>
-        viewsOf(b.slug) - viewsOf(a.slug) ||
-        recencyOf(a.slug) - recencyOf(b.slug),
-    )
-    .slice(0, count)
-    .map((post) => ({ ...post, views: viewsOf(post.slug) }));
+  const bySlug = new Map(posts.map((post) => [post.slug, post]));
+  const ranked: PopularPost[] = [];
+  for (const item of items) {
+    if (ranked.length >= count) break;
+    const post = bySlug.get(item.slug);
+    // 지워졌거나 중복으로 적힌 슬러그는 건너뛴다.
+    if (!post) continue;
+    bySlug.delete(item.slug);
+    ranked.push({ ...post, views: item.views });
+  }
 
   if (ranked.length >= count) return ranked;
 

--- a/src/lib/posts.ts
+++ b/src/lib/posts.ts
@@ -275,7 +275,7 @@ export function getTagCounts(posts: PostMeta[]): TagCount[] {
 }
 
 /**
- * 인기 글 Top N. data/popular.json(GA4 ko/en 합산 조회수)의 내림차순.
+ * 인기 글 Top N. data/popular.json(GA4 ko/en 합산 조회수)에 적힌 순서 그대로.
  * 조회수 데이터가 없으면 예전처럼 최신순으로 폴백한다(src/lib/popular.ts 참고).
  */
 export function getPopularPosts(


### PR DESCRIPTION
rankPostsByViews가 스냅샷을 조회수 맵으로만 쓰고 자체 재정렬하면서,
동점일 때 최신 글을 앞세웠다. 수집 스크립트는 동점을 슬러그순으로 굽기
때문에 조회수 3짜리가 셋인 지금 3~5위가 파일과 어긋나 보였다.

items 배열을 순위로 그대로 훑도록 바꿨다. 정렬 책임은 수집 스크립트
하나로 모인다. 삭제된 글 건너뛰기, 모자란 자리 최신순 채우기(views:
null), 빈 스냅샷 폴백은 그대로다. 순회 방식이라 중복 슬러그가 두 번
들어갈 수 있어 bySlug.delete로 막았다.

## 개요

<!---- 변경 사항 및 관련 이슈에 대해 간단하게 작성해주세요. 어떻게보다 무엇을 왜 수정했는지 설명해주세요. -->

<!---- Resolves: #(Isuue Number) -->

## PR 유형

어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist

PR이 다음 요구 사항을 충족하는지 확인하세요.

- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
- [ ] eslint, stylelint 파일 포멧팅 검사를 수행했습니다.
